### PR TITLE
Fix JSON encoding for non-ASCII filenames

### DIFF
--- a/.github/workflows/upload-markdown-on-change.yml
+++ b/.github/workflows/upload-markdown-on-change.yml
@@ -71,7 +71,7 @@ jobs:
             cmd = ["git", "show", "--name-status", "--pretty=format:", "--no-renames", "-z", after_sha]
 
           print(f"[debug] cmd={' '.join(cmd)}")
-          diff_output = subprocess.check_output(cmd, text=True)
+          diff_output = subprocess.check_output(cmd, encoding="utf-8")
           print("[debug] raw diff output:")
           print(repr(diff_output) if diff_output else "(empty)")
 
@@ -123,7 +123,7 @@ jobs:
               "filename": rel_path,
               "markdown": markdown,
             }
-            data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            data = json.dumps(payload).encode("utf-8")
             req = urllib.request.Request(
               endpoint,
               data=data,
@@ -151,7 +151,7 @@ jobs:
             payload = {
               "filename": rel_path,
             }
-            data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+            data = json.dumps(payload).encode("utf-8")
             req = urllib.request.Request(
               endpoint,
               data=data,


### PR DESCRIPTION
## Summary
- Use `ensure_ascii=True` (default) in `json.dumps` so non-ASCII characters like `á` are encoded as `\u00e1` — pure ASCII JSON that avoids body parsing issues on the server's DELETE endpoint
- Use explicit `encoding="utf-8"` for subprocess output instead of `text=True` to avoid locale-dependent decoding on CI runners

## Context
The sync workflow fails for filenames like `2025-11-14-Interview-with-Visegrád-24.md`:
- DELETE returns HTTP 400 `{"error":"Invalid JSON body"}` — the raw UTF-8 `á` byte (`\xc3\xa1`) in the JSON body can't be parsed by the server's DELETE handler
- POST then returns HTTP 409 `Filename already exists` since the DELETE didn't remove it

🤖 Generated with [Claude Code](https://claude.com/claude-code)